### PR TITLE
Bug 948434 - [marionette-file-manager] removeAllFiles cannot work before the device storage is not initialized

### DIFF
--- a/lib/desktop_client_file_manager.js
+++ b/lib/desktop_client_file_manager.js
@@ -74,7 +74,15 @@ DesktopClientFileManager.prototype = {
    * Remove all files and directories in device storage.
    */
   removeAllFiles: function() {
-    this._removeFile(this.deviceStorage.getDeviceStoragePath());
+    var deviceStoragePath = this.deviceStorage.getDeviceStoragePath(),
+        fileList = [];
+
+    if (fs.existsSync(deviceStoragePath)) {
+      fileList = fs.readdirSync(deviceStoragePath);
+      fileList.forEach(function(item) {
+        this._removeFile(path.join(deviceStoragePath, item));
+      }.bind(this));
+    }
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marionette-file-manager",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "Evan Tseng",
     "email": "evanxd@mozilla.com"

--- a/test/integration/index_test.js
+++ b/test/integration/index_test.js
@@ -1,14 +1,17 @@
-const TEST_FILES_PATH = '../test_files',
-      TEXT_FILE_NAME = 'hello_world.json',
-      IMAGE_FILE_NAME = 'fxos.png',
-      PICTURES_TYPE = 'pictures',
-      TEXT_TYPE = 'text';
-
 var assert = require('assert'),
     fs = require('fs'),
     path = require('path'),
     testHelper = require('../lib/test_helper'),
     client = {};
+
+const TEST_FILES_PATH = '../test_files',
+      TEXT_FILE_NAME = 'hello_world.json',
+      IMAGE_FILE_NAME = 'fxos.png',
+      PICTURES_TYPE = 'pictures',
+      TEXT_TYPE = 'text',
+      DS_FILE_PATH = path.join(TEXT_TYPE, TEXT_FILE_NAME),
+      TEST_FILE_PATH =
+        path.join(__dirname, TEST_FILES_PATH, TEXT_FILE_NAME);
 
 suite('MarionetteFileManager', function() {
   var testFilePath =
@@ -40,10 +43,6 @@ suite('MarionetteFileManager', function() {
 
   suite('#add', function() {
     test('should get the file from device storage', function() {
-      const DS_FILE_PATH = path.join(TEXT_TYPE, TEXT_FILE_NAME),
-            TEST_FILE_PATH =
-              path.join(__dirname, TEST_FILES_PATH, TEXT_FILE_NAME);
-
       client.fileManager.add({
         type: TEXT_TYPE,
         filePath: path.join(__dirname, TEST_FILES_PATH, TEXT_FILE_NAME)
@@ -91,6 +90,23 @@ suite('MarionetteFileManager', function() {
         ['pictures'],
         function(error, value) {
           assert.ok(value.files.length === 0);
+        }
+      );
+    });
+
+    test('could add file after do removeAllFiles', function() {
+      client.fileManager.removeAllFiles();
+      client.fileManager.add({
+        type: TEXT_TYPE,
+        filePath: path.join(__dirname, TEST_FILES_PATH, TEXT_FILE_NAME)
+      });
+
+      client.executeAsyncScript(
+        getFileFromDeviceStorage,
+        [DS_FILE_PATH],
+        function(error, value) {
+          var expectedContent = fs.readFileSync(TEST_FILE_PATH).toString();
+          assert.deepEqual(value.file.toString(), expectedContent);
         }
       );
     });

--- a/test/unit/desktop_client_file_manager_test.js
+++ b/test/unit/desktop_client_file_manager_test.js
@@ -78,8 +78,8 @@ suite('DesktopClientFileManager', function() {
       ]);
 
       fileList = fs.readdirSync(deviceStorage.getMediaFilePath(PICTURES_TYPE));
-      assert.deepEqual(TEST_FILE_1, fileList[0]);
-      assert.deepEqual(TEST_FILE_2, fileList[1]);
+      assert.ok(fileList.indexOf(TEST_FILE_1) !== -1);
+      assert.ok(fileList.indexOf(TEST_FILE_2) !== -1);
     });
   });
 
@@ -104,17 +104,23 @@ suite('DesktopClientFileManager', function() {
   });
 
   suite('#removeAllFiles', function() {
-    setup(function() {
+    test('should have device storage directory', function() {
+      subject.removeAllFiles();
+      assert.ok(fs.existsSync(DEVICE_STORAGE_PATH));
+    });
+
+    test('should work when no file in device storage', function() {
+      subject.removeAllFiles();
+      assert.ok(fs.readdirSync(DEVICE_STORAGE_PATH).length === 0);
+    });
+
+    test('should remove all files in device storage', function() {
       subject.add({
         type: PICTURES_TYPE,
         filePath: path.join(__dirname, TEST_FILES_PATH, TEST_FILE_NAME)
       });
-    });
 
-    test('should remove all files in device storage', function() {
       subject.removeAllFiles();
-      // XXX: Could not be passed by the below assert.
-      // assert.ok(!fs.existsSync(DEVICE_STORAGE_PATH));
       assert.ok(fs.readdirSync(DEVICE_STORAGE_PATH).length === 0);
     });
   });


### PR DESCRIPTION
Make sure we have device storage directory when we do add function.
http://bugzil.la/948434
